### PR TITLE
Add support for event emitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,29 @@
 
 _dependencies last pinned 1/8/20_
 
+## Listening to events
+
+#### How to use
+
+All listeners functions are defined inside `dappHero` object.
+
+For example to listen after a contract method result it's outputed to the DOM you can simple call:
+
+```javascript
+dappHero.listenToContractOutputChange(event => {
+   console.log(`Event changed`, event)
+})
+```
+
+#### Supported events currently are for:
+
+- [x] Custom Contract
+- [ ] Network
+- [ ] NFT
+- [ ] ThreeBox
+- [ ] User
+
+
 ### E2E Testing
 
 1. Fulfill the following env variables:

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "loggly-jslogger": "^2.2.2",
     "logrocket": "^1.0.6",
     "mini-css-extract-plugin": "0.8.0",
+    "mitt": "^1.2.0",
     "multicodec": "^0.5.7",
     "optimize-css-assets-webpack-plugin": "5.0.3",
     "pnp-webpack-plugin": "1.5.0",

--- a/src/Activator.tsx
+++ b/src/Activator.tsx
@@ -5,6 +5,8 @@ import * as consts from 'consts'
 import * as contexts from 'contexts'
 import { loggerTest } from 'logger/loggerTest'
 
+import { EVENT_NAMES } from 'providers/EmitterProvider/constants'
+import { EmitterContext } from 'providers/EmitterProvider/context'
 import { FeatureReducer } from './protocol/ethereum/featureReducer'
 
 // Log tests and Startup Logs
@@ -18,6 +20,7 @@ type ActivatorProps = {
 
 export const Activator = ({ configuration, highlightDomElements }: ActivatorProps) => {
   const domElements = useContext(contexts.DomElementsContext)
+  const { actions: { listenToEvent } } = useContext(EmitterContext)
 
   const attemptedEagerConnect = hooks.useEagerConnect()
 
@@ -33,6 +36,7 @@ export const Activator = ({ configuration, highlightDomElements }: ActivatorProp
         dappHero.highlightEnabled = !dappHero.highlightEnabled
         highlightDomElements(dappHero.highlightEnabled)
       },
+      listenToContractOutputChange: (cb): void => listenToEvent(EVENT_NAMES.contract.outputUpdated, cb),
     }
 
     Object.assign(window, { dappHero })

--- a/src/ProvidersWrapper.tsx
+++ b/src/ProvidersWrapper.tsx
@@ -10,6 +10,7 @@ import * as api from 'api'
 import { ethers } from 'ethers'
 import * as consts from 'consts'
 import { DomElementsContext } from 'contexts'
+import { EmitterProvider } from 'providers/EmitterProvider/provider'
 
 import { Activator } from './Activator'
 import { logger } from './logger/customLogger'
@@ -66,15 +67,17 @@ export const ProvidersWrapper: React.FC = () => {
 
   if (domElements != null) {
     return (
-      <CookiesProvider>
-        <ToastProvider>
-          <Web3ReactProvider getLibrary={getLibrary}>
-            <DomElementsContext.Provider value={domElements}>
-              <Activator configuration={configuration} highlightDomElements={highlightDomElements} />
-            </DomElementsContext.Provider>
-          </Web3ReactProvider>
-        </ToastProvider>
-      </CookiesProvider>
+      <EmitterProvider>
+        <CookiesProvider>
+          <ToastProvider>
+            <Web3ReactProvider getLibrary={getLibrary}>
+              <DomElementsContext.Provider value={domElements}>
+                <Activator configuration={configuration} highlightDomElements={highlightDomElements} />
+              </DomElementsContext.Provider>
+            </Web3ReactProvider>
+          </ToastProvider>
+        </CookiesProvider>
+      </EmitterProvider>
     )
   }
   return null

--- a/src/protocol/ethereum/customContract/Reducer.tsx
+++ b/src/protocol/ethereum/customContract/Reducer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useContext } from 'react'
 import { useToasts } from 'react-toast-notifications'
 import Notify from 'bnc-notify'
 import { ethers } from 'ethers'
@@ -7,6 +7,9 @@ import { logger } from 'logger/customLogger'
 import omit from 'lodash.omit'
 import * as consts from 'consts'
 import { useWeb3React } from '@web3-react/core'
+
+import { EVENT_NAMES } from 'providers/EmitterProvider/constants'
+import { EmitterContext } from 'providers/EmitterProvider/context'
 
 const blockNativeApiKey = process.env.REACT_APP_BLOCKNATIVE_API
 const POLLING_INTERVAL = 1000
@@ -48,6 +51,7 @@ export const Reducer = ({ info, configuration }) => {
 
   // Injected Web3 Context
   const injectedContext = useWeb3React()
+  const { actions: { emitToEvent } } = useContext(EmitterContext)
 
   // Toast Notifications
   const { addToast } = useToasts()
@@ -286,9 +290,13 @@ export const Reducer = ({ info, configuration }) => {
             } else {
               Object.assign(element, { textContent: convertedValue })
             }
+
+            emitToEvent(EVENT_NAMES.contract.outputUpdated, { value: convertedValue, element })
           } else {
             Object.assign(element, { textContent: parsedValue })
+            emitToEvent(EVENT_NAMES.contract.outputUpdated, { value: parsedValue, element })
           }
+
         })
       }
 
@@ -304,16 +312,21 @@ export const Reducer = ({ info, configuration }) => {
             ? utils.convertUnits(contractUnits, displayUnits, parsedValue[outputName])
             : parsedValue[outputName]
           const isNumber = !Number.isNaN(Number(convertedValue))
+
           if (decimals && isNumber) {
             const decimalConvertedValue = Number(convertedValue)
               .toFixed(decimals)
               .toString()
             element.innerText = decimalConvertedValue
+
+            emitToEvent(EVENT_NAMES.contract.outputUpdated, { value: decimalConvertedValue, element })
           } else {
             Object.assign(element, { textContent: convertedValue })
+            emitToEvent(EVENT_NAMES.contract.outputUpdated, { value: convertedValue, element })
           }
         })
       }
+
     }
   }, [ result ])
 

--- a/src/providers/EmitterProvider/constants.ts
+++ b/src/providers/EmitterProvider/constants.ts
@@ -1,0 +1,1 @@
+export const EVENT_NAMES = { contract: { outputUpdated: 'contract:outputUpdated' } }

--- a/src/providers/EmitterProvider/context.tsx
+++ b/src/providers/EmitterProvider/context.tsx
@@ -1,0 +1,25 @@
+import { createContext } from 'react'
+import mitt from 'mitt'
+
+// types
+import { ListenToEvent, EmitToEvent } from './types'
+
+type StateContext = {
+  emitter?: mitt.Emitter;
+}
+
+type ActionsContext = {
+  listenToEvent: ListenToEvent;
+  emitToEvent: EmitToEvent;
+}
+
+type Context = {
+  state: StateContext;
+  actions: ActionsContext;
+}
+
+export const EmitterContext = createContext<Context>({
+  state: { emitter: null },
+  actions: { listenToEvent: null, emitToEvent: null },
+})
+

--- a/src/providers/EmitterProvider/provider.tsx
+++ b/src/providers/EmitterProvider/provider.tsx
@@ -1,0 +1,25 @@
+import React, { useMemo, useCallback } from 'react'
+import mitt from 'mitt'
+
+// context
+import { EmitterContext } from './context'
+
+// types
+import { ListenToEvent, EmitToEvent } from './types'
+
+export const EmitterProvider = ({ children }) => {
+  const emitter = useMemo(() => mitt(), [])
+
+  const listenToEvent: ListenToEvent = useCallback((eventName, cb) => emitter.on(eventName, cb ), [])
+  const emitToEvent: EmitToEvent = useCallback((eventName, data) => emitter.emit(eventName, data ), [])
+
+  const state = useMemo(() => ({ emitter }), [])
+  const actions = useMemo(() => ({ listenToEvent, emitToEvent }), [])
+
+  return (
+    <EmitterContext.Provider value={{ state, actions }}>
+      {children}
+    </EmitterContext.Provider>
+  )
+}
+

--- a/src/providers/EmitterProvider/types.ts
+++ b/src/providers/EmitterProvider/types.ts
@@ -1,0 +1,3 @@
+
+export type ListenToEvent = (eventName: string, cb: (e: any) => void) => void
+export type EmitToEvent = (eventName: string, data: any) => void


### PR DESCRIPTION
We want to give the users the ability to listen when DappHero makes some changes or certain actions, i.e when we update the DOM to output in each element the contract methods results, the `listenToContractOutputChange` it's triggered per each element and gives back in the `event` an object with the `value` and the `element`. An use case could be: when the user hook up to this listener and afterwards do some special parsing to their output.
 
```javascript
dappHero.listenToContractOutputChange(event => {
   console.log(`Event changed`, event)
})
```