### PR TITLE
Add ability to force refresh engine

### DIFF
--- a/src/Activator.tsx
+++ b/src/Activator.tsx
@@ -15,10 +15,11 @@ loggerTest()
 // TODO: Type configuration
 type ActivatorProps = {
   configuration: any;
+  retriggerEngine: () => void;
   highlightDomElements: (shouldHighlight: boolean) => void;
 }
 
-export const Activator = ({ configuration, highlightDomElements }: ActivatorProps) => {
+export const Activator = ({ configuration, highlightDomElements, retriggerEngine }: ActivatorProps) => {
   const domElements = useContext(contexts.DomElementsContext)
   const { actions: { listenToEvent } } = useContext(EmitterContext)
 
@@ -31,6 +32,7 @@ export const Activator = ({ configuration, highlightDomElements }: ActivatorProp
       highlightEnabled: false,
       domElements,
       configuration,
+      retriggerEngine,
       projectId: consts.global.apiKey,
       toggleHighlight(): void {
         dappHero.highlightEnabled = !dappHero.highlightEnabled

--- a/src/ProvidersWrapper.tsx
+++ b/src/ProvidersWrapper.tsx
@@ -21,6 +21,7 @@ export const ProvidersWrapper: React.FC = () => {
   // react hooks
   const [ configuration, setConfig ] = useState(null)
   const [ domElements, setDomElements ] = useState(null)
+  const [ timestamp, setTimestamp ] = useState(+new Date())
 
   // effects
   useEffect(() => {
@@ -65,6 +66,8 @@ export const ProvidersWrapper: React.FC = () => {
     })
   }
 
+  const retriggerEngine = (): void => setTimestamp(+new Date())
+
   if (domElements != null) {
     return (
       <EmitterProvider>
@@ -72,7 +75,7 @@ export const ProvidersWrapper: React.FC = () => {
           <ToastProvider>
             <Web3ReactProvider getLibrary={getLibrary}>
               <DomElementsContext.Provider value={domElements}>
-                <Activator configuration={configuration} highlightDomElements={highlightDomElements} />
+                <Activator configuration={configuration} retriggerEngine={retriggerEngine} highlightDomElements={highlightDomElements} />
               </DomElementsContext.Provider>
             </Web3ReactProvider>
           </ToastProvider>


### PR DESCRIPTION
We want to give the users to run DappHero Core again if they desire to:

```javascript
window.dappHero.retriggerEngine()
// or without window
dappHero.retriggerEngine()
```