### PR TITLE
Emit configLoaded event

### DIFF
--- a/src/Activator.tsx
+++ b/src/Activator.tsx
@@ -24,7 +24,7 @@ type ActivatorProps = {
 export const Activator = ({ configuration, highlightDomElements, retriggerEngine }: ActivatorProps) => {
   // React hooks
   const domElements = useContext(contexts.DomElementsContext)
-  const { actions: { listenToEvent, emitToEvent } } = useContext(EmitterContext)
+  const { actions: { listenToEvent } } = useContext(EmitterContext)
 
   // Custom hooks
   const attemptedEagerConnect = hooks.useEagerConnect()
@@ -47,9 +47,10 @@ export const Activator = ({ configuration, highlightDomElements, retriggerEngine
       listenToContractOutputChange: (cb): void => listenToEvent(EVENT_NAMES.contract.outputUpdated, cb),
     }
 
-    Object.assign(window, { dappHero })
+    const event = new CustomEvent('dappHeroConfigLoaded', { detail: dappHero })
 
-    emitToEvent('dappHeroConfigLoaded', dappHero)
+    // Dispatch the event.
+    window.dispatchEvent(event)
   }, [ web3React, web3React.library ])
 
   if (attemptedEagerConnect) {


### PR DESCRIPTION
We need a way that the dappHero clients know when the object config it's available so we're going to trigger a CustomEvent from the native Browser APIs.
We cannot use our custom emitter since they'll need beforehand the emitter instance.


The users will do something like:
```javascript
// Listen for the event.
window.addEventListener('dappHeroConfigLoaded', ({ detail: dappHero }) => {
  console.log('DappHero config object available!', dappHero)

  dappHero.listenToContractOutputChange((data) => {
    console.log('Output changed!', data)
  })
})
```
