### PR TITLE
🐛 FIX: Prevent memory leak by delaying the autoInvoke by 100ms.

### DIFF
--- a/src/protocol/ethereum/customContract/useAutoInvokeMethod.tsx
+++ b/src/protocol/ethereum/customContract/useAutoInvokeMethod.tsx
@@ -23,8 +23,8 @@ export const useAutoInvokeMethod = ({
 
       if (autoInvokeValue === 'true' && !isTransaction) {
 
-        // Call the run method instantly before starting to poll.
-        handleRunMethod(null, true)
+        // Call the run method instantly (100ms) before starting to poll.
+        const timeout = setTimeout(() => handleRunMethod(null, true), 100)
         const intervalId = setInterval(() => {
           emitToEvent(
             EVENT_NAMES.contract.invokeTrigger,
@@ -35,7 +35,11 @@ export const useAutoInvokeMethod = ({
 
         setAutoInterval(intervalId)
 
-        return (): void => clearInterval(intervalId)
+        const clear = (): void => {
+          clearInterval(intervalId)
+          clearTimeout(timeout)
+        }
+        return (): void => clear()
       }
     }
   }, [ readEnabled, readContract, writeAddress ])


### PR DESCRIPTION
I am not 100% sure why this should work, but basically the refresh is happening too quickly for auto invoke, essentially the component has been unmounted and remounted before the original autoinvoke returns data. In this case we simply delay firing the auto invoke function by 100ms to see if the page is ready. 